### PR TITLE
Fix PR check

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -8,7 +8,7 @@ on:
 
   pull_request:
     paths:
-      - '.github\workflows\pr-check.yml'
+      - '.github/workflows/**'
 
 jobs:
   deploy:

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -1,13 +1,17 @@
 name: pr-check
 
+# Note: If you need to make changes to this file, please use a branch off the main branch instead of a fork.
+# The pull_request target from a forked repo will not have access to the secrets needed for this workflow.
+
 on:
   pull_request_target:
 
   pull_request:
+    paths:
+      - '.github\workflows\pr-check.yml'
 
 jobs:
   deploy:
-    if: (github.event == 'pull_request' && github.event.pull_request.head.repo == github.repository.full_name) || (github.event == 'pull_request_target' && github.event.pull_request.head.repo != github.repository.full_name)
     environment: Automation test
     runs-on: ${{ matrix.os }}
     strategy:


### PR DESCRIPTION
I don't think the condition on the job works as intended as `github.event == 'pull_request'` evaluates to false all the time.

Changed pr-check.yml to use pull_request_target by default. Additionally we will run the pull_request target if changes are detected in the yml file.