### PR TITLE
Fix arguments not being passed to sqlcmd

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -70,7 +70,8 @@ function getInputs(): IActionInputs {
             return {
                 actionType: ActionType.SqlAction,
                 connectionConfig: connectionConfig,
-                filePath: filePath
+                filePath: filePath,
+                additionalArguments: core.getInput('arguments') || undefined
             };
 
         case Constants.dacpacExtension:


### PR DESCRIPTION
Updates input-parsing to include additional arguments for `.sql`-file actions.

Fixes #144