### PR TITLE
Remove path from pull_request_target

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -5,9 +5,6 @@ name: pr-check
 
 on:
   pull_request_target:
-    paths:
-      - '!.github/workflows/pr-check.yml'
-
   pull_request:
     paths:
       - '.github/workflows/pr-check.yml'


### PR DESCRIPTION
I added the path in last PR trying to prevent requiring both `pull_request` and `pull_request_target` from firing, but now it looks like `pull_request_target` isn't firing any more even when it satisfies the path specification. I'll just revert my last change here.