### PR TITLE
Only run AAD Default test in PR check, add adhoc workflow

### DIFF
--- a/.github/workflows/adhoc-tests.yml
+++ b/.github/workflows/adhoc-tests.yml
@@ -1,13 +1,8 @@
-name: pr-check
+name: adhoc-tests
 
-# Note: If you need to make changes to this file, please use a branch off the main branch instead of a fork.
-# The pull_request target from a forked repo will not have access to the secrets needed for this workflow.
+# Manually trigger this workflow, test auth/connection settings by setting the ADHOC_CONNECTION_STRING_NO_DATABASE GitHub secret.
 
-on:
-  pull_request_target:
-  pull_request:
-    paths:
-      - '.github/workflows/pr-check.yml'
+on: workflow_dispatch
 
 permissions:
   id-token: write # This is needed for Azure login with OIDC
@@ -25,14 +20,11 @@ jobs:
         os: [windows-latest, ubuntu-latest]
 
     env:
-      TEST_DB: 'SqlActionTest-${{ matrix.os }}'
+      TEST_DB: 'SqlActionAdhocTest-${{ matrix.os }}'
 
     steps:
-    - name: Checkout from PR branch
+    - name: Checkout
       uses: actions/checkout@v4
-      with:
-        repository: ${{ github.event.pull_request.head.repo.full_name }}
-        ref: ${{ github.event.pull_request.head.ref }}
 
     - name: Installing node_modules
       run: npm install
@@ -51,7 +43,7 @@ jobs:
     - name: Test DACPAC Action
       uses: ./
       with:
-        connection-string: 'Server=${{ secrets.TEST_SERVER }};Initial Catalog=${{ env.TEST_DB }};Authentication=Active Directory Default;'
+        connection-string: '${{ secrets.ADHOC_CONNECTION_STRING_NO_DATABASE }}Initial Catalog=${{ env.TEST_DB }};'
         path: ./__testdata__/sql-action.dacpac
         action: 'publish'
 
@@ -59,7 +51,7 @@ jobs:
     - name: Test Build and Publish
       uses: ./
       with:
-        connection-string: 'Server=${{ secrets.TEST_SERVER }};Initial Catalog=${{ env.TEST_DB }};Authentication=Active Directory Default;'
+        connection-string: '${{ secrets.ADHOC_CONNECTION_STRING_NO_DATABASE }}Initial Catalog=${{ env.TEST_DB }};'
         path: ./__testdata__/TestProject/sql-action.sqlproj
         action: 'publish'
 
@@ -67,13 +59,13 @@ jobs:
     - name: Test SQL Action
       uses: ./
       with:
-        connection-string: 'Server=${{ secrets.TEST_SERVER }};Initial Catalog=${{ env.TEST_DB }};Authentication=Active Directory Default;'
+        connection-string: '${{ secrets.ADHOC_CONNECTION_STRING_NO_DATABASE }}Initial Catalog=${{ env.TEST_DB }};'
         path: ./__testdata__/testsql.sql
 
     - name: Cleanup Test Database
       if: always()
       uses: ./
       with: 
-        connection-string: 'Server=${{ secrets.TEST_SERVER }};Initial Catalog=master;Authentication=Active Directory Default;'
+        connection-string: '${{ secrets.ADHOC_CONNECTION_STRING_NO_DATABASE }}Initial Catalog=master;'
         path: ./__testdata__/cleanup.sql
         arguments: '-v DbName="${{ env.TEST_DB }}"'


### PR DESCRIPTION
In pr-check, only test against AAD Default connection
Add an adhoc-tests workflow where connection string can be set for different settings