### PR TITLE
Update CONNECTION when using Service Principal

### DIFF
--- a/CONNECTION.md
+++ b/CONNECTION.md
@@ -146,6 +146,12 @@ ALTER ROLE [db_ddladmin]
 ADD MEMBER [sqldeployserviceprincipal];
 ```
 
+You might also need to create the user in the master database:
+```sql
+USE master
+CREATE USER [sqldeployserviceprincipal] FROM EXTERNAL PROVIDER;
+```
+
 The connection string for Azure Active Directory service principal authentication is:
 
 ```


### PR DESCRIPTION
I noticed that my deployments failed when the external user was missing in the master db. To mitigate this issue, I had to create the external user in both the database and in the master database.

A related issue seems to have been mentioned before: https://github.com/Azure/sql-action/issues/213

**User only created in db, not in master db:**
_Initializing deployment (Start)
Initializing deployment (Failed)
*** An error occurred during deployment plan generation. Deployment cannot continue.
Login failed for user '***@***'.
Time elapsed 0:00:26.67
Error: The process 'sqlpackage' failed with exit code 1_

**User created in db and in master db:**
_Initializing deployment (Start)
*** The object [data_0] exists in the target, but it will not be dropped even though you selected the 'Generate drop statements for objects that are in the target database but that are not in the source' check box.
*** The object [log] exists in the target, but it will not be dropped even though you selected the 'Generate drop statements for objects that are in the target database but that are not in the source' check box.
Initializing deployment (Complete)
Analyzing deployment plan (Start)
Analyzing deployment plan (Complete)
Updating database (Start)
'QUERY_STORE=OFF' is not supported in this version of SQL Server.
Starting rebuilding table [dbo].[Example]...
Caution: Changing any part of an object name could break scripts and stored procedures.
Caution: Changing any part of an object name could break scripts and stored procedures.
Update complete.
Updating database (Complete)
Successfully published database.
Changes to connection setting default values were incorporated in a recent release.  More information is available at https://aka.ms/dacfx-connection
Time elapsed 0:02:04.86
Successfully executed action Publish on target database._

**Changes:**
- Added step for master db when using service principal