### PR TITLE
Upgrade action runtime from node20 to node24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -24,5 +24,5 @@ inputs:
     required: false
     default: false
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'lib/main.js'


### PR DESCRIPTION
# Description

Resolves #274 - Node.js 20 actions are deprecated and will be forced to run with Node.js 24 starting June 2nd, 2026.

# Code Changes

- [ ] [Unit tests](/__tests__/) are added, if possible
- [ ] New or changed code follows the C# style guidelines defined in .editorconfig
- [ ] All changes MUST be backwards compatible and changes to the shared `az_func.GlobalState` table must be compatible with all prior versions of the extension
- [ ] Use `core.debug` or directly log to console to display relevant information
- [ ] Use `async` and `await` for all long-running operations

# Dependencies

- [ ] If updating dependencies, run `npm install` to update the lock files and ensure that there are NO major versions updates or additional vulnerabilities in [package-lock.json](/package-lock.json). If there are, contact the dev team for instructions.

# Documentation

- [ ] Updates to the [action definition](/action.yml) should also update the [README](/README.md)
- [ ] Add [samples](/README.md#-samples) if the change is modifying or adding functionality