### PR TITLE
Explain swallow-by-design parse-failure handling in DeploymentReport

### DIFF
--- a/src/DeploymentReport.ts
+++ b/src/DeploymentReport.ts
@@ -54,6 +54,9 @@ export function parseDeploymentReport(xml: string): DeploymentReport {
     try {
         parsed = parser.parse(xml);
     } catch {
+        // Reporting is best-effort and must never fail a deployment: malformed or
+        // unexpected report XML yields an empty result so the summary simply omits
+        // the changes section instead of surfacing an error.
         return { operations: [], alerts: [] };
     }
 


### PR DESCRIPTION
Small follow-up to #279. Adds the code comment Benjin suggested, explaining why the deployment report parser swallows parse failures (reporting is best-effort and must never fail a deployment). Comment-only, no logic or behavior change.